### PR TITLE
Check if this.audio is available before setting state

### DIFF
--- a/src/js/components/bar/components/controls/index.js
+++ b/src/js/components/bar/components/controls/index.js
@@ -93,10 +93,12 @@ class Controls extends Component {
 
    createTimeInterval() {
       this.playInterval = setInterval(() => {
-         this.props.updateTime({
-            current: this.audio.currentTime,
-            max: this.audio.duration,
-         });
+         if (this.audio) {
+            this.props.updateTime({
+               current: this.audio.currentTime,
+               max: this.audio.duration,
+            });
+         }
       }, 1000);
    }
 


### PR DESCRIPTION
I got an error while running the app locally. Probably happened because the `playInterval` wasn't cleared correctly. 

This should fix the error, although the interval should still be cleared (couldn't find where this went wrong exactly).